### PR TITLE
Support sample weights in all circa*() functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,11 @@ Authors@R:
            family = "Parsons",
            role = c("aut", "cre"),
            email = "Rex.Parsons94@gmail.com",
-           comment = c(ORCID = "0000-0002-6053-8174"))
+           comment = c(ORCID = "0000-0002-6053-8174")),
+    person(given = "Alexander",
+           family = "Bender",
+           role = c("ctb"),
+           email = "atpoint90@gmail.com")
 Description: Uses non-linear regression to statistically compare two circadian rhythms.
     Groups are only compared if both are rhythmic (amplitude is non-zero).
     Performs analyses regarding mesor, phase, and amplitude, reporting on estimates and statistical differences, for each, between groups.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: circacompare
 Title: Analyses of Circadian Data
-Version: 0.1.1.9000
+Version: 0.1.1.9001
 Authors@R: 
     c(person(given = "Rex",
              family = "Parsons",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,15 +2,15 @@ Package: circacompare
 Title: Analyses of Circadian Data
 Version: 0.1.1.9000
 Authors@R: 
-    person(given = "Rex",
-           family = "Parsons",
-           role = c("aut", "cre"),
-           email = "Rex.Parsons94@gmail.com",
-           comment = c(ORCID = "0000-0002-6053-8174")),
-    person(given = "Alexander",
-           family = "Bender",
-           role = c("ctb"),
-           email = "atpoint90@gmail.com")
+    c(person(given = "Rex",
+             family = "Parsons",
+             role = c("aut", "cre"),
+             email = "Rex.Parsons94@gmail.com",
+             comment = c(ORCID = "0000-0002-6053-8174")),
+       person(given = "Alexander",
+              family = "Bender",
+              role = c("ctb"),
+              email = "atpoint90@gmail.com"))
 Description: Uses non-linear regression to statistically compare two circadian rhythms.
     Groups are only compared if both are rhythmic (amplitude is non-zero).
     Performs analyses regarding mesor, phase, and amplitude, reporting on estimates and statistical differences, for each, between groups.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Uses non-linear regression to statistically compare two circadian r
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Imports: 
     ggplot2 (>= 2.2.1),
     stats

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: circacompare
 Title: Analyses of Circadian Data
-Version: 0.1.1.9001
+Version: 0.1.1.9000
 Authors@R: 
     c(person(given = "Rex",
              family = "Parsons",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,7 @@
 
 ## Improvements
 
-* allow per-sample weights in `circacompare()`. This is experimental as it has only been added to the
-`nls()` function that runs the actual differential analysis, not to the ones in the `model_each_group` function which models both groups separately to assess per-group rhythmicity.
+* allow per-sample weights in `circacompare()` and `circa_single()`. This allows to downweight individual samples, for example in the case of outliers rather than hard-filtered them which reduces power. Such per-sample weights can reproducibly be estimated using approaches such as `arrayWeights()` in the [limma](https://bioconductor.org/packages/release/bioc/html/limma.html) package for datasets with many genes/observations, such as RNA-seq or microarrays.
 
 # circacompare 0.1.1.9000
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,8 @@
-# circacompare 0.1.1.9001
+# circacompare 0.1.1.9000
 
 ## Improvements
 
 * support per-sample weights in `circacompare()`, `circa_single()`, `circa_single_mixed()` and `circacompare_mixed()`
-
-# circacompare 0.1.1.9000
-
-## Improvements
 
 * better error messages - also makes the shiny app more verbose for users
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# circacompare 0.1.1.9001
+
+## Improvements
+
+* allow per-sample weights in `circacompare()`. This is experimental as it has only been added to the
+`nls()` function that runs the actual differential analysis, not to the ones in the `model_each_group` function which models both groups separately to assess per-group rhythmicity.
+
 # circacompare 0.1.1.9000
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Improvements
 
-* allow per-sample weights in `circacompare()` and `circa_single()`. This allows to downweight individual samples, for example in the case of outliers rather than hard-filtered them which reduces power. Such per-sample weights can reproducibly be estimated using approaches such as `arrayWeights()` in the [limma](https://bioconductor.org/packages/release/bioc/html/limma.html) package for datasets with many genes/observations, such as RNA-seq or microarrays.
+* support per-sample weights in `circacompare()`, `circa_single()`, `circa_single_mixed()` and `circacompare_mixed()`
 
 # circacompare 0.1.1.9000
 

--- a/R/circa_single.R
+++ b/R/circa_single.R
@@ -24,13 +24,13 @@
 #' out
 #'
 #' # with sample weights (arbitrary weights for demonstration)
-#' sw <- runif(n=nrow(df))
+#' sw <- runif(n = nrow(df))
 #' out2 <- circa_single(
 #'   x = df,
 #'   col_time = "time",
-#'    col_outcome = "measure",
-#'    weights = sw,
-#'    suppress_all = TRUE
+#'   col_outcome = "measure",
+#'   weights = sw,
+#'   suppress_all = TRUE
 #' )
 #' out2
 #'
@@ -97,10 +97,12 @@ circa_single <- function(x,
     }
   }
 
-  if(!is.null(weights)){
+  if (!is.null(weights)) {
     check_weights(x, weights)
     x$weights <- weights
-  } else x$weights <- rep(1, nrow(x))
+  } else {
+    x$weights <- rep(1, nrow(x))
+  }
 
   success <- FALSE
   n <- 0

--- a/R/circa_single.R
+++ b/R/circa_single.R
@@ -25,7 +25,13 @@
 #'
 #' # with sample weights (arbitrary weights for demonstration)
 #' sw <- runif(n=nrow(df))
-#' out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", weights = sw, suppress_all = TRUE)
+#' out2 <- circa_single(
+#'   x = df,
+#'   col_time = "time",
+#'    col_outcome = "measure",
+#'    weights = sw,
+#'    suppress_all = TRUE
+#' )
 #' out2
 #'
 circa_single <- function(x,

--- a/R/circa_single.R
+++ b/R/circa_single.R
@@ -11,7 +11,7 @@
 #' @param timeout_n The upper limit for the model fitting attempts. Default is 10,000.
 #' @param return_figure Whether or not to return a ggplot graph of the rhythm and cosine model.
 #' @param control \code{list}. Used to control the parameterization of the model.
-#' @param sample_weights A numeric vector of per-sample weights to allow downweighting of outlier samples.
+#' @param weights A numeric vector of per-sample weights.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.
 #'
 #' @return list
@@ -22,13 +22,12 @@
 #' df <- df[df$group == "g1", ]
 #' out <- circa_single(x = df, col_time = "time", col_outcome = "measure")
 #' out
-#' 
+#'
 #' # with sample weights (arbitrary weights for demonstration)
-#' set.seed(1)
-#' sw <- jitter(rep(1, nrow(df)), factor=1.5)
-#' out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", sample_weights = sw, suppress_all = TRUE)
+#' sw <- runif(n=nrow(df))
+#' out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", weights = sw, suppress_all = TRUE)
 #' out2
-#' 
+#'
 circa_single <- function(x,
                          col_time,
                          col_outcome,
@@ -37,7 +36,7 @@ circa_single <- function(x,
                          timeout_n = 10000,
                          return_figure = TRUE,
                          control = list(),
-                         sample_weights = NULL,
+                         weights = NULL,
                          suppress_all = FALSE) {
   controlVals <- circa_single_control()
   controlVals[names(control)] <- control
@@ -91,14 +90,12 @@ circa_single <- function(x,
       ))
     }
   }
-  
-  if(!is.null(sample_weights)){
-    l.weights <- length(sample_weights)
-    if(l.weights != nrow(x) | sum(is.na(sample_weights)) > 0 | sum(sample_weights <= 0) > 0 | !is.numeric(sample_weights))
-      stop("sample_weights must be numeric, positive, non-zero, non-NA and of same length as the number of rows in x")
-    x$sample_weights <- sample_weights
-  } else x$sample_weights <- rep(1, nrow(x))
-  
+
+  if(!is.null(weights)){
+    check_weights(x, weights)
+    x$weights <- weights
+  } else x$weights <- rep(1, nrow(x))
+
   success <- FALSE
   n <- 0
   form <- create_formula(main_params = controlVals$main_params, decay_params = controlVals$decay_params)$formula
@@ -110,7 +107,7 @@ circa_single <- function(x,
           formula = form,
           data = x,
           start = start_list(outcome = x$measure, controlVals = controlVals),
-          weights = sample_weights
+          weights = weights
         )
       },
       silent = suppress_all

--- a/R/circa_single.R
+++ b/R/circa_single.R
@@ -11,7 +11,7 @@
 #' @param timeout_n The upper limit for the model fitting attempts. Default is 10,000.
 #' @param return_figure Whether or not to return a ggplot graph of the rhythm and cosine model.
 #' @param control \code{list}. Used to control the parameterization of the model.
-#' @param weights A numeric vector of per-sample weights.
+#' @param weights An optional numeric vector of (fixed) weights. When present, the objective function is weighted least squares.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.
 #'
 #' @return list

--- a/R/circa_single_mixed.R
+++ b/R/circa_single_mixed.R
@@ -12,6 +12,7 @@
 #' @param alpha_threshold The level of alpha for which the presence of rhythmicity is considered. Default is to \code{0.05}.
 #' @param nlme_control A list of control values for the estimation algorithm to replace the default values returned by the function nlme::nlmeControl. Defaults to an empty list.
 #' @param nlme_method A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "ML".
+#' @param weights A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.
 #' @param timeout_n The upper limit for the model fitting attempts. Default is \code{10000}.
 #' @param return_figure Whether or not to return a ggplot graph of the rhythm and cosine model.
@@ -41,6 +42,14 @@
 #'   x = df, col_time = "time", col_outcome = "measure",
 #'   col_id = "id", randomeffects = c("k")
 #' )
+#'
+#' # with sample weights (arbitrary weights for demonstration)
+#' sw <- runif(n=nrow(df))
+#' out2 <- circa_single_mixed(
+#'   x = df, col_time = "time", col_outcome = "measure",
+#'   col_id = "id", randomeffects = c("k"), weights = sw
+#' )
+#'
 circa_single_mixed <- function(x,
                                col_time,
                                col_outcome,
@@ -50,6 +59,7 @@ circa_single_mixed <- function(x,
                                alpha_threshold = 0.05,
                                nlme_control = list(),
                                nlme_method = "ML",
+                               weights = NULL,
                                suppress_all = FALSE,
                                timeout_n = 10000,
                                return_figure = TRUE,
@@ -124,6 +134,11 @@ circa_single_mixed <- function(x,
     }
   }
 
+  if(!is.null(weights)){
+    check_weights(x, weights)
+    x$weights <- weights
+  } else x$weights <- rep(1, nrow(x))
+
   success <- FALSE
   n <- 0
   form <- create_formula(main_params = controlVals$main_params, decay_params = controlVals$decay_params)$formula
@@ -141,7 +156,8 @@ circa_single_mixed <- function(x,
           start = unlist(start_list(outcome = x$measure, controlVals = controlVals)),
           control = nlme_control,
           method = nlme_method,
-          verbose = !suppress_all
+          verbose = !suppress_all,
+          weights = nlme::varPower(form=~weights)
         )
       },
       silent = ifelse(suppress_all, TRUE, FALSE)

--- a/R/circa_single_mixed.R
+++ b/R/circa_single_mixed.R
@@ -45,7 +45,7 @@
 #' )
 #'
 #' # with sample weights (arbitrary weights for demonstration)
-#' sw <- runif(n=nrow(df))
+#' sw <- runif(n = nrow(df))
 #' out2 <- circa_single_mixed(
 #'   x = df, col_time = "time", col_outcome = "measure",
 #'   col_id = "id", randomeffects = c("k"), weights = sw
@@ -135,10 +135,12 @@ circa_single_mixed <- function(x,
     }
   }
 
-  if(!is.null(weights)){
+  if (!is.null(weights)) {
     check_weights(x, weights)
     x$weights <- weights
-  } else x$weights <- rep(1, nrow(x))
+  } else {
+    x$weights <- rep(1, nrow(x))
+  }
 
   success <- FALSE
   n <- 0
@@ -158,7 +160,7 @@ circa_single_mixed <- function(x,
           control = nlme_control,
           method = nlme_method,
           verbose = !suppress_all,
-          weights = nlme::varPower(form=~weights)
+          weights = nlme::varPower(form = ~weights)
         )
       },
       silent = ifelse(suppress_all, TRUE, FALSE)

--- a/R/circa_single_mixed.R
+++ b/R/circa_single_mixed.R
@@ -12,7 +12,8 @@
 #' @param alpha_threshold The level of alpha for which the presence of rhythmicity is considered. Default is to \code{0.05}.
 #' @param nlme_control A list of control values for the estimation algorithm to replace the default values returned by the function nlme::nlmeControl. Defaults to an empty list.
 #' @param nlme_method A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "ML".
-#' @param weights A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
+#' @param weights An optional numeric vector of (fixed) weights internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
+#' When present, the objective function is weighted least squares.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.
 #' @param timeout_n The upper limit for the model fitting attempts. Default is \code{10000}.
 #' @param return_figure Whether or not to return a ggplot graph of the rhythm and cosine model.

--- a/R/circacompare.R
+++ b/R/circacompare.R
@@ -11,7 +11,7 @@
 #' @param alpha_threshold The level of alpha for which the presence of rhythmicity is considered. Default is 0.05.
 #' @param timeout_n The upper limit for the model fitting attempts. Default is 10,000.
 #' @param control \code{list}. Used to control the parameterization of the model.
-#' @param weights A numeric vector of per-sample weights to allow downweighting of outlier samples.
+#' @param weights An optional numeric vector of (fixed) weights. When present, the objective function is weighted least squares.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.
 #'
 #' @return list

--- a/R/circacompare.R
+++ b/R/circacompare.R
@@ -26,7 +26,7 @@
 #' out
 #'
 #' # with sample weights (arbitrary weights for demonstration)
-#' sw <- runif(n=nrow(df))
+#' sw <- runif(n = nrow(df))
 #' out2 <- circacompare(
 #'   x = df, col_time = "time", col_group = "group",
 #'   col_outcome = "measure", weights = sw
@@ -62,19 +62,19 @@ circacompare <- function(x,
 
   if (!class(x$time) %in% c("numeric", "integer")) {
     stop(paste("The time variable which you gave was a '",
-               class(x$time),
-               "' \nThis function expects time to be given as hours and be of class 'integer' or 'numeric'.",
-               "\nPlease convert the time variable in your dataframe to be of one of these classes",
-               sep = ""
+      class(x$time),
+      "' \nThis function expects time to be given as hours and be of class 'integer' or 'numeric'.",
+      "\nPlease convert the time variable in your dataframe to be of one of these classes",
+      sep = ""
     ))
   }
 
   if (!class(x$measure) %in% c("numeric", "integer")) {
     stop(paste("The measure variable which you gave was a '",
-               class(x$measure),
-               "' \nThis function expects measure to be number and be of class 'integer' or 'numeric'.",
-               "\nPlease convert the measure variable in your dataframe to be of one of these classes",
-               sep = ""
+      class(x$measure),
+      "' \nThis function expects measure to be number and be of class 'integer' or 'numeric'.",
+      "\nPlease convert the measure variable in your dataframe to be of one of these classes",
+      sep = ""
     ))
   }
 
@@ -102,10 +102,12 @@ circacompare <- function(x,
     }
   }
 
-  if(!is.null(weights)){
+  if (!is.null(weights)) {
     check_weights(x, weights)
     x$weights <- weights
-  } else x$weights <- rep(1, nrow(x))
+  } else {
+    x$weights <- rep(1, nrow(x))
+  }
 
   group_1_text <- levels(as.factor(x$group))[1]
   group_2_text <- levels(as.factor(x$group))[2]

--- a/R/circacompare.R
+++ b/R/circacompare.R
@@ -11,7 +11,7 @@
 #' @param alpha_threshold The level of alpha for which the presence of rhythmicity is considered. Default is 0.05.
 #' @param timeout_n The upper limit for the model fitting attempts. Default is 10,000.
 #' @param control \code{list}. Used to control the parameterization of the model.
-#' @param sample_weights a numeric vector of per-sample weights (one per sample) to allow downweighting of outliers in the differential analysis
+#' @param sample_weights A numeric vector of per-sample weights to allow downweighting of outlier samples.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.
 #'
 #' @return list
@@ -24,13 +24,16 @@
 #'   col_outcome = "measure"
 #' )
 #' out
-#' # with sample weights
+#' 
+#' # with sample weights (arbitrary weights for demonstration)
 #' set.seed(1)
 #' sw <- jitter(rep(1, nrow(df)), factor=2)
-#' out <- circacompare(
+#' out2 <- circacompare(
 #'   x = df, col_time = "time", col_group = "group",
 #'   col_outcome = "measure", sample_weights = sw
 #' )
+#' out2
+#' 
 circacompare <- function(x,
                          col_time,
                          col_group,
@@ -99,6 +102,13 @@ circacompare <- function(x,
       ))
     }
   }
+  
+  if(!is.null(sample_weights)){
+    l.weights <- length(sample_weights)
+    if(l.weights != nrow(x) | sum(is.na(sample_weights)) > 0 | sum(sample_weights <= 0) > 0 | !is.numeric(sample_weights))
+      stop("sample_weights must be numeric, positive, non-zero, non-NA and of same length as the number of rows in x")
+    x$sample_weights <- sample_weights
+  } else x$sample_weights <- rep(1, nrow(x))
 
   group_1_text <- levels(as.factor(x$group))[1]
   group_2_text <- levels(as.factor(x$group))[2]
@@ -147,13 +157,6 @@ circacompare <- function(x,
       stop(group_2_text, " was arrhythmic (to the power specified by the argument 'alpha_threshold').\nThe data was, therefore, not used for a comparison between the two groups.")
     }
   }
-
-  if(!is.null(sample_weights)){
-    l.weights <- length(sample_weights)
-    if(l.weights != nrow(x) | sum(is.na(sample_weights)) > 0 | sum(sample_weights <= 0) > 0 | !is.numeric(sample_weights))
-      stop("sample_weights must be numeric, positive, non-zero, non-NA and of same length as the number of rows in x")
-    x$sample_weights <- sample_weights
-  } else x$sample_weights <- rep(1, nrow(x))
 
   n <- 0
   success <- FALSE

--- a/R/circacompare_mixed.R
+++ b/R/circacompare_mixed.R
@@ -13,7 +13,8 @@
 #' @param alpha_threshold The level of alpha for which the presence of rhythmicity is considered. Default is to \code{0.05}.
 #' @param nlme_control A list of control values for the estimation algorithm to replace the default values returned by the function nlme::nlmeControl. Defaults to an empty list.
 #' @param nlme_method A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "REML".
-#' @param weights A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
+#' @param weights An optional numeric vector of (fixed) weights internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
+#' When present, the objective function is weighted least squares.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.
 #' @param timeout_n The upper limit for the model fitting attempts. Default is \code{10000}.
 #' @param control \code{list}. Used to control the parameterization of the model.

--- a/R/circacompare_mixed.R
+++ b/R/circacompare_mixed.R
@@ -13,6 +13,7 @@
 #' @param alpha_threshold The level of alpha for which the presence of rhythmicity is considered. Default is to \code{0.05}.
 #' @param nlme_control A list of control values for the estimation algorithm to replace the default values returned by the function nlme::nlmeControl. Defaults to an empty list.
 #' @param nlme_method A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "REML".
+#' @param weights A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
 #' @param suppress_all Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.
 #' @param timeout_n The upper limit for the model fitting attempts. Default is \code{10000}.
 #' @param control \code{list}. Used to control the parameterization of the model.
@@ -48,7 +49,18 @@
 #'   col_id = "id",
 #'   control = list(grouped_params = c("phi"), random_params = c("phi1"))
 #' )
-#' out
+#'
+#' # with sample weights (arbitrary weights for demonstration)
+#' sw <- runif(n=nrow(df))
+#' out2 <- circacompare_mixed(
+#'   x = df,
+#'   col_time = "time",
+#'   col_group = "group",
+#'   col_outcome = "measure",
+#'   col_id = "id",
+#'   control = list(grouped_params = c("phi"), random_params = c("phi1")),
+#'   weights = sw
+#' )
 #'
 circacompare_mixed <- function(x,
                                col_time,
@@ -60,6 +72,7 @@ circacompare_mixed <- function(x,
                                alpha_threshold = 0.05,
                                nlme_control = list(),
                                nlme_method = "REML",
+                               weights = NULL,
                                suppress_all = FALSE,
                                timeout_n = 10000,
                                control = list()) {
@@ -137,6 +150,11 @@ circacompare_mixed <- function(x,
     }
   }
 
+  if(!is.null(weights)){
+    check_weights(x, weights)
+    x$weights <- weights
+  } else x$weights <- rep(1, nrow(x))
+
   group_1_text <- levels(as.factor(x$group))[1]
   group_2_text <- levels(as.factor(x$group))[2]
 
@@ -210,7 +228,8 @@ circacompare_mixed <- function(x,
           start = unlist(start_list_grouped(g1 = g1_model$model, g2 = g2_model$model, grouped_params = controlVals$grouped_params)),
           method = nlme_method,
           control = nlme_control,
-          verbose = !suppress_all
+          verbose = !suppress_all,
+          weights = nlme::varPower(form=~weights)
         )
       },
       silent = ifelse(suppress_all, TRUE, FALSE)

--- a/R/circacompare_mixed.R
+++ b/R/circacompare_mixed.R
@@ -52,7 +52,7 @@
 #' )
 #'
 #' # with sample weights (arbitrary weights for demonstration)
-#' sw <- runif(n=nrow(df))
+#' sw <- runif(n = nrow(df))
 #' out2 <- circacompare_mixed(
 #'   x = df,
 #'   col_time = "time",
@@ -151,10 +151,12 @@ circacompare_mixed <- function(x,
     }
   }
 
-  if(!is.null(weights)){
+  if (!is.null(weights)) {
     check_weights(x, weights)
     x$weights <- weights
-  } else x$weights <- rep(1, nrow(x))
+  } else {
+    x$weights <- rep(1, nrow(x))
+  }
 
   group_1_text <- levels(as.factor(x$group))[1]
   group_2_text <- levels(as.factor(x$group))[2]
@@ -230,7 +232,7 @@ circacompare_mixed <- function(x,
           method = nlme_method,
           control = nlme_control,
           verbose = !suppress_all,
-          weights = nlme::varPower(form=~weights)
+          weights = nlme::varPower(form = ~weights)
         )
       },
       silent = ifelse(suppress_all, TRUE, FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -39,7 +39,7 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
             method = args$nlme_method,
             control = args$nlme_control,
             verbose = args$verbose,
-            weights = nlme::varPower(form=~weights)
+            weights = nlme::varPower(form = ~weights)
           )
         },
         silent = ifelse(args$verbose, FALSE, TRUE)
@@ -455,18 +455,18 @@ circa_summary <- function(model, period, control,
   return(res)
 }
 
-check_weights <-function(x, weights){
-
+check_weights <- function(x, weights) {
   len_weights <- length(weights)
   len_x <- nrow(x)
 
-  if(len_weights != len_x)
+  if (len_weights != len_x) {
     stop("weights must have the same length as the number of rows in x")
+  }
 
   contains_na_or_negative <- sum(is.na(weights) | weights < 0) > 0
   non_numeric <- !is.numeric(weights)
 
-  if(contains_na_or_negative | non_numeric)
+  if (contains_na_or_negative | non_numeric) {
     stop("weights be not be negative or contain NAs/missing values")
-
+  }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,7 +47,8 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
           stats::nls(
             formula = form,
             data = data,
-            start = starting_params
+            start = starting_params,
+            weights = sample_weights # come from "data" object via the circacompare() and circa_single() functions
           )
         },
         silent = args$suppress_all

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,8 +18,8 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
   success <- FALSE
   n <- 0
 
-  if(!"sample_weights" %in% colnames(data)) data$sample_weights <- rep(1, nrow(data))
-    
+  if(!"weights" %in% colnames(data)) data$weights <- rep(1, nrow(data))
+
   while (!success) {
     starting_params <- start_list(outcome = data$measure, controlVals = controlVals)
     # use the nls function below if the only random effects are on group parameters
@@ -50,7 +50,7 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
             formula = form,
             data = data,
             start = starting_params,
-            weights = sample_weights
+            weights = weights
           )
         },
         silent = args$suppress_all
@@ -452,4 +452,20 @@ circa_summary <- function(model, period, control,
   }
 
   return(res)
+}
+
+check_weights <-function(x, weights){
+
+  len_weights <- length(weights)
+  len_x <- nrow(x)
+
+  if(len_weights != len_x)
+    stop("weights must have the same length as the number of rows in x")
+
+  contains_na <- sum(is.na(weights)) > 0
+  non_numeric <- !is.numeric(weights)
+
+  if(contains_na | non_numeric)
+    stop("weights be not be negative or contain NAs/missing values")
+
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -461,10 +461,10 @@ check_weights <-function(x, weights){
   if(len_weights != len_x)
     stop("weights must have the same length as the number of rows in x")
 
-  contains_na <- sum(is.na(weights)) > 0
+  contains_na_or_negative <- sum(is.na(weights) | weights < 0) > 0
   non_numeric <- !is.numeric(weights)
 
-  if(contains_na | non_numeric)
+  if(contains_na_or_negative | non_numeric)
     stop("weights be not be negative or contain NAs/missing values")
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,8 +18,6 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
   success <- FALSE
   n <- 0
 
-  if(!"weights" %in% colnames(data)) data$weights <- rep(1, nrow(data))
-
   while (!success) {
     starting_params <- start_list(outcome = data$measure, controlVals = controlVals)
     # use the nls function below if the only random effects are on group parameters
@@ -38,7 +36,8 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
             start = unlist(starting_params),
             method = args$nlme_method,
             control = args$nlme_control,
-            verbose = args$verbose
+            verbose = args$verbose,
+            weights = nlme::varPower(form=~weights)
           )
         },
         silent = ifelse(args$verbose, FALSE, TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,6 @@
-utils::globalVariables(c("time", "measure", "group", "eq", "eq_1", "eq_2"))
+utils::globalVariables(
+  c("time", "measure", "group", "eq", "eq_1", "eq_2", "weights")
+)
 
 extract_model_coefs <- function(model) {
   if ("nls" %in% class(model)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,6 +18,8 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
   success <- FALSE
   n <- 0
 
+  if(!"sample_weights" %in% colnames(data)) data$sample_weights <- rep(1, nrow(data))
+    
   while (!success) {
     starting_params <- start_list(outcome = data$measure, controlVals = controlVals)
     # use the nls function below if the only random effects are on group parameters
@@ -48,7 +50,7 @@ model_each_group <- function(data, type, form = stats::as.formula("measure~k+alp
             formula = form,
             data = data,
             start = starting_params,
-            weights = sample_weights # come from "data" object via the circacompare() and circa_single() functions
+            weights = sample_weights
           )
         },
         silent = args$suppress_all

--- a/man/circa_single.Rd
+++ b/man/circa_single.Rd
@@ -51,13 +51,13 @@ out <- circa_single(x = df, col_time = "time", col_outcome = "measure")
 out
 
 # with sample weights (arbitrary weights for demonstration)
-sw <- runif(n=nrow(df))
+sw <- runif(n = nrow(df))
 out2 <- circa_single(
   x = df,
   col_time = "time",
-   col_outcome = "measure",
-   weights = sw,
-   suppress_all = TRUE
+  col_outcome = "measure",
+  weights = sw,
+  suppress_all = TRUE
 )
 out2
 

--- a/man/circa_single.Rd
+++ b/man/circa_single.Rd
@@ -13,7 +13,7 @@ circa_single(
   timeout_n = 10000,
   return_figure = TRUE,
   control = list(),
-  sample_weights = NULL,
+  weights = NULL,
   suppress_all = FALSE
 )
 }
@@ -34,7 +34,7 @@ circa_single(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
-\item{sample_weights}{A numeric vector of per-sample weights to allow downweighting of outlier samples.}
+\item{weights}{A numeric vector of per-sample weights.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }
@@ -51,9 +51,8 @@ out <- circa_single(x = df, col_time = "time", col_outcome = "measure")
 out
 
 # with sample weights (arbitrary weights for demonstration)
-set.seed(1)
-sw <- jitter(rep(1, nrow(df)), factor=1.5)
-out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", sample_weights = sw, suppress_all = TRUE)
+sw <- runif(n=nrow(df))
+out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", weights = sw, suppress_all = TRUE)
 out2
 
 }

--- a/man/circa_single.Rd
+++ b/man/circa_single.Rd
@@ -52,7 +52,13 @@ out
 
 # with sample weights (arbitrary weights for demonstration)
 sw <- runif(n=nrow(df))
-out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", weights = sw, suppress_all = TRUE)
+out2 <- circa_single(
+  x = df,
+  col_time = "time",
+   col_outcome = "measure",
+   weights = sw,
+   suppress_all = TRUE
+)
 out2
 
 }

--- a/man/circa_single.Rd
+++ b/man/circa_single.Rd
@@ -34,7 +34,7 @@ circa_single(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
-\item{weights}{A numeric vector of per-sample weights.}
+\item{weights}{An optional numeric vector of (fixed) weights. When present, the objective function is weighted least squares.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }

--- a/man/circa_single.Rd
+++ b/man/circa_single.Rd
@@ -13,6 +13,7 @@ circa_single(
   timeout_n = 10000,
   return_figure = TRUE,
   control = list(),
+  sample_weights = NULL,
   suppress_all = FALSE
 )
 }
@@ -33,6 +34,8 @@ circa_single(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
+\item{sample_weights}{A numeric vector of per-sample weights to allow downweighting of outlier samples.}
+
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }
 \value{
@@ -44,5 +47,13 @@ list
 \examples{
 df <- make_data()
 df <- df[df$group == "g1", ]
-circa_single(x = df, col_time = "time", col_outcome = "measure")
+out <- circa_single(x = df, col_time = "time", col_outcome = "measure")
+out
+
+# with sample weights (arbitrary weights for demonstration)
+set.seed(1)
+sw <- jitter(rep(1, nrow(df)), factor=1.5)
+out2 <- circa_single(x = df, col_time = "time", col_outcome = "measure", sample_weights = sw, suppress_all = TRUE)
+out2
+
 }

--- a/man/circa_single_mixed.Rd
+++ b/man/circa_single_mixed.Rd
@@ -40,7 +40,8 @@ circa_single_mixed(
 
 \item{nlme_method}{A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "ML".}
 
-\item{weights}{A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.}
+\item{weights}{An optional numeric vector of (fixed) weights internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
+When present, the objective function is weighted least squares.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.}
 

--- a/man/circa_single_mixed.Rd
+++ b/man/circa_single_mixed.Rd
@@ -14,6 +14,7 @@ circa_single_mixed(
   alpha_threshold = 0.05,
   nlme_control = list(),
   nlme_method = "ML",
+  weights = NULL,
   suppress_all = FALSE,
   timeout_n = 10000,
   return_figure = TRUE,
@@ -38,6 +39,8 @@ circa_single_mixed(
 \item{nlme_control}{A list of control values for the estimation algorithm to replace the default values returned by the function nlme::nlmeControl. Defaults to an empty list.}
 
 \item{nlme_method}{A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "ML".}
+
+\item{weights}{A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.}
 
@@ -74,4 +77,12 @@ out <- circa_single_mixed(
   x = df, col_time = "time", col_outcome = "measure",
   col_id = "id", randomeffects = c("k")
 )
+
+# with sample weights (arbitrary weights for demonstration)
+sw <- runif(n=nrow(df))
+out2 <- circa_single_mixed(
+  x = df, col_time = "time", col_outcome = "measure",
+  col_id = "id", randomeffects = c("k"), weights = sw
+)
+
 }

--- a/man/circa_single_mixed.Rd
+++ b/man/circa_single_mixed.Rd
@@ -80,7 +80,7 @@ out <- circa_single_mixed(
 )
 
 # with sample weights (arbitrary weights for demonstration)
-sw <- runif(n=nrow(df))
+sw <- runif(n = nrow(df))
 out2 <- circa_single_mixed(
   x = df, col_time = "time", col_outcome = "measure",
   col_id = "id", randomeffects = c("k"), weights = sw

--- a/man/circacompare.Rd
+++ b/man/circacompare.Rd
@@ -53,7 +53,7 @@ out <- circacompare(
 out
 
 # with sample weights (arbitrary weights for demonstration)
-sw <- runif(n=nrow(df))
+sw <- runif(n = nrow(df))
 out2 <- circacompare(
   x = df, col_time = "time", col_group = "group",
   col_outcome = "measure", weights = sw

--- a/man/circacompare.Rd
+++ b/man/circacompare.Rd
@@ -34,7 +34,7 @@ circacompare(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
-\item{sample_weights}{a numeric vector of per-sample weights (one per sample) to allow downweighting of outliers in the differential analysis}
+\item{sample_weights}{A numeric vector of per-sample weights to allow downweighting of outlier samples.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }
@@ -51,11 +51,14 @@ out <- circacompare(
   col_outcome = "measure"
 )
 out
-# with sample weights
+
+# with sample weights (arbitrary weights for demonstration)
 set.seed(1)
 sw <- jitter(rep(1, nrow(df)), factor=2)
-out <- circacompare(
+out2 <- circacompare(
   x = df, col_time = "time", col_group = "group",
   col_outcome = "measure", sample_weights = sw
 )
+out2
+
 }

--- a/man/circacompare.Rd
+++ b/man/circacompare.Rd
@@ -34,7 +34,7 @@ circacompare(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
-\item{weights}{A numeric vector of per-sample weights to allow downweighting of outlier samples.}
+\item{weights}{An optional numeric vector of (fixed) weights. When present, the objective function is weighted least squares.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }

--- a/man/circacompare.Rd
+++ b/man/circacompare.Rd
@@ -13,7 +13,7 @@ circacompare(
   alpha_threshold = 0.05,
   timeout_n = 10000,
   control = list(),
-  sample_weights = NULL,
+  weights = NULL,
   suppress_all = FALSE
 )
 }
@@ -34,7 +34,7 @@ circacompare(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
-\item{sample_weights}{A numeric vector of per-sample weights to allow downweighting of outlier samples.}
+\item{weights}{A numeric vector of per-sample weights to allow downweighting of outlier samples.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }
@@ -53,11 +53,10 @@ out <- circacompare(
 out
 
 # with sample weights (arbitrary weights for demonstration)
-set.seed(1)
-sw <- jitter(rep(1, nrow(df)), factor=2)
+sw <- runif(n=nrow(df))
 out2 <- circacompare(
   x = df, col_time = "time", col_group = "group",
-  col_outcome = "measure", sample_weights = sw
+  col_outcome = "measure", weights = sw
 )
 out2
 

--- a/man/circacompare.Rd
+++ b/man/circacompare.Rd
@@ -13,6 +13,7 @@ circacompare(
   alpha_threshold = 0.05,
   timeout_n = 10000,
   control = list(),
+  sample_weights = NULL,
   suppress_all = FALSE
 )
 }
@@ -33,6 +34,8 @@ circacompare(
 
 \item{control}{\code{list}. Used to control the parameterization of the model.}
 
+\item{sample_weights}{a numeric vector of per-sample weights (one per sample) to allow downweighting of outliers in the differential analysis}
+
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}.}
 }
 \value{
@@ -48,4 +51,11 @@ out <- circacompare(
   col_outcome = "measure"
 )
 out
+# with sample weights
+set.seed(1)
+sw <- jitter(rep(1, nrow(df)), factor=2)
+out <- circacompare(
+  x = df, col_time = "time", col_group = "group",
+  col_outcome = "measure", sample_weights = sw
+)
 }

--- a/man/circacompare_mixed.Rd
+++ b/man/circacompare_mixed.Rd
@@ -87,7 +87,7 @@ out <- circacompare_mixed(
 )
 
 # with sample weights (arbitrary weights for demonstration)
-sw <- runif(n=nrow(df))
+sw <- runif(n = nrow(df))
 out2 <- circacompare_mixed(
   x = df,
   col_time = "time",

--- a/man/circacompare_mixed.Rd
+++ b/man/circacompare_mixed.Rd
@@ -42,7 +42,8 @@ circacompare_mixed(
 
 \item{nlme_method}{A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "REML".}
 
-\item{weights}{A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.}
+\item{weights}{An optional numeric vector of (fixed) weights internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.
+When present, the objective function is weighted least squares.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.}
 

--- a/man/circacompare_mixed.Rd
+++ b/man/circacompare_mixed.Rd
@@ -15,6 +15,7 @@ circacompare_mixed(
   alpha_threshold = 0.05,
   nlme_control = list(),
   nlme_method = "REML",
+  weights = NULL,
   suppress_all = FALSE,
   timeout_n = 10000,
   control = list()
@@ -40,6 +41,8 @@ circacompare_mixed(
 \item{nlme_control}{A list of control values for the estimation algorithm to replace the default values returned by the function nlme::nlmeControl. Defaults to an empty list.}
 
 \item{nlme_method}{A character string. If "REML" the model is fit by maximizing the restricted log-likelihood. If "ML" the log-likelihood is maximized. Defaults to "REML".}
+
+\item{weights}{A numeric vector of per-sample weights, internally passed to \code{nlme::nlme()} via \code{nlme::varPower()}.}
 
 \item{suppress_all}{Logical. Set to \code{TRUE} to avoid seeing errors or messages during model fitting procedure. Default is \code{FALSE}. If \code{FALSE}, also runs \code{nlme()} with \code{verbose = TRUE}.}
 
@@ -81,6 +84,17 @@ out <- circacompare_mixed(
   col_id = "id",
   control = list(grouped_params = c("phi"), random_params = c("phi1"))
 )
-out
+
+# with sample weights (arbitrary weights for demonstration)
+sw <- runif(n=nrow(df))
+out2 <- circacompare_mixed(
+  x = df,
+  col_time = "time",
+  col_group = "group",
+  col_outcome = "measure",
+  col_id = "id",
+  control = list(grouped_params = c("phi"), random_params = c("phi1")),
+  weights = sw
+)
 
 }

--- a/tests/testthat/test-circa_single.R
+++ b/tests/testthat/test-circa_single.R
@@ -103,14 +103,14 @@ test_that("weights work", {
 
   # all weights should be 1
   df <- make_data(phi1 = 6)
-  df <- df[df$group == "g1",]
+  df <- df[df$group == "g1", ]
   out <- circa_single(
     x = df, col_time = "time", col_outcome = "measure"
   )
   expect_true(all(out$fit$weights == 1))
 
   # all weights should not be 1
-  sw <- runif(n=nrow(df))
+  sw <- runif(n = nrow(df))
   out2 <- circa_single(
     x = df, col_time = "time", col_outcome = "measure", weights = sw
   )
@@ -141,5 +141,4 @@ test_that("weights work", {
       x = df, col_time = "time", col_outcome = "measure", weights = sw4, timeout_n = 1
     )
   )
-
 })

--- a/tests/testthat/test-circa_single.R
+++ b/tests/testthat/test-circa_single.R
@@ -97,3 +97,49 @@ test_that("suppress_all works", {
   )
   expect_true(length(output) == 0)
 })
+
+### make test that weights are used correctly and malformatted weights are detected
+test_that("weights work", {
+
+  # all weights should be 1
+  df <- make_data(phi1 = 6)
+  df <- df[df$group == "g1",]
+  out <- circa_single(
+    x = df, col_time = "time", col_outcome = "measure"
+  )
+  expect_true(all(out$fit$weights == 1))
+
+  # all weights should not be 1
+  sw <- runif(n=nrow(df))
+  out2 <- circa_single(
+    x = df, col_time = "time", col_outcome = "measure", weights = sw
+  )
+  expect_false(all(out2$fit$weights == 1))
+
+  # weights must be same length as nrow(x)
+  sw2 <- c(sw, 1)
+  expect_error(
+    circa_single(
+      x = df, col_time = "time", col_outcome = "measure", weights = sw2
+    )
+  )
+
+  # weights must not contain NA
+  sw3 <- sw
+  sw3[1] <- NA
+  expect_error(
+    circa_single(
+      x = df, col_time = "time", col_outcome = "measure", weights = sw3
+    )
+  )
+
+  # weights must not be negative
+  sw4 <- sw
+  sw4[1] <- -1
+  expect_error(
+    circa_single(
+      x = df, col_time = "time", col_outcome = "measure", weights = sw4, timeout_n = 1
+    )
+  )
+
+})

--- a/tests/testthat/test-circa_single_mixed.R
+++ b/tests/testthat/test-circa_single_mixed.R
@@ -40,3 +40,70 @@ test_that("circa_single_mixed() works", {
   tau_ul <- tau_est + 1.96 * fit_tau["std_error"]
   expect_true(tau_in < tau_ul & tau_in > tau_ll)
 })
+
+### make test that weights are used correctly and malformatted weights are detected
+test_that("weights work", {
+
+  set.seed(42)
+  mixed_data <- function(n) {
+   counter <- 1
+   for (i in 1:n) {
+     x <- make_data(k1 = rnorm(1, 10, 2), alpha1 = 0, phi1 = 0)
+     x$id <- counter
+     counter <- counter + 1
+     if (i == 1) {
+       res <- x
+     } else {
+       res <- rbind(res, x)
+     }
+   }
+   return(res)
+  }
+
+  df <- mixed_data(n = 50)
+
+  # no weights used (= all weights are 1), hence fit$apVar should not be populated
+  out <- circa_single_mixed(
+   x = df, col_time = "time", col_outcome = "measure",
+   col_id = "id", randomeffects = c("k")
+  )
+  expect_true(is(out$fit$apVar, "character"))
+
+  # when weights are not all 1 then fit$apVar should be a matrix
+  sw <- runif(n=nrow(df))
+  out2 <- circa_single_mixed(
+    x = df, col_time = "time", col_outcome = "measure",
+    col_id = "id", randomeffects = c("k"), weights = sw
+  )
+  expect_true(is(out2$fit$apVar, "matrix"))
+
+  # weights must be same length as nrow(x)
+  sw2 <- c(sw, 1)
+  expect_error(
+    circa_single_mixed(
+      x = df, col_time = "time", col_outcome = "measure",
+      col_id = "id", randomeffects = c("k"), weights = sw2
+    )
+  )
+
+  # weights must not contain NA
+  sw3 <- sw
+  sw3[1] <- NA
+  expect_error(
+    circa_single_mixed(
+      x = df, col_time = "time", col_outcome = "measure",
+      col_id = "id", randomeffects = c("k"), weights = sw3
+    )
+  )
+
+  # weights must not be negative
+  sw4 <- sw
+  sw4[1] <- -1
+  expect_error(
+    circa_single_mixed(
+      x = df, col_time = "time", col_outcome = "measure",
+      col_id = "id", randomeffects = c("k"), weights = sw4
+    )
+  )
+
+})

--- a/tests/testthat/test-circa_single_mixed.R
+++ b/tests/testthat/test-circa_single_mixed.R
@@ -43,34 +43,33 @@ test_that("circa_single_mixed() works", {
 
 ### make test that weights are used correctly and malformatted weights are detected
 test_that("weights work", {
-
   set.seed(42)
   mixed_data <- function(n) {
-   counter <- 1
-   for (i in 1:n) {
-     x <- make_data(k1 = rnorm(1, 10, 2), alpha1 = 0, phi1 = 0)
-     x$id <- counter
-     counter <- counter + 1
-     if (i == 1) {
-       res <- x
-     } else {
-       res <- rbind(res, x)
-     }
-   }
-   return(res)
+    counter <- 1
+    for (i in 1:n) {
+      x <- make_data(k1 = rnorm(1, 10, 2), alpha1 = 0, phi1 = 0)
+      x$id <- counter
+      counter <- counter + 1
+      if (i == 1) {
+        res <- x
+      } else {
+        res <- rbind(res, x)
+      }
+    }
+    return(res)
   }
 
   df <- mixed_data(n = 50)
 
   # no weights used (= all weights are 1), hence fit$apVar should not be populated
   out <- circa_single_mixed(
-   x = df, col_time = "time", col_outcome = "measure",
-   col_id = "id", randomeffects = c("k")
+    x = df, col_time = "time", col_outcome = "measure",
+    col_id = "id", randomeffects = c("k")
   )
   expect_true(is(out$fit$apVar, "character"))
 
   # when weights are not all 1 then fit$apVar should be a matrix
-  sw <- runif(n=nrow(df))
+  sw <- runif(n = nrow(df))
   out2 <- circa_single_mixed(
     x = df, col_time = "time", col_outcome = "measure",
     col_id = "id", randomeffects = c("k"), weights = sw
@@ -105,5 +104,4 @@ test_that("weights work", {
       col_id = "id", randomeffects = c("k"), weights = sw4
     )
   )
-
 })

--- a/tests/testthat/test-circacompare.R
+++ b/tests/testthat/test-circacompare.R
@@ -66,7 +66,7 @@ test_that("weights work", {
   expect_true(all(out$fit$weights == 1))
 
   # all weights should not be 1
-  sw <- runif(n=nrow(df))
+  sw <- runif(n = nrow(df))
   out2 <- circacompare(
     x = df, col_time = "time", col_outcome = "measure", col_group = "group",
     weights = sw
@@ -90,5 +90,4 @@ test_that("weights work", {
       weights = sw3
     )
   )
-
 })

--- a/tests/testthat/test-circacompare.R
+++ b/tests/testthat/test-circacompare.R
@@ -54,3 +54,41 @@ test_that("circacompare() fits a good model to generated data", {
   alpha_decay1_ul <- alpha_decay1_est + 1.96 * fit_alpha_decay1["std_error"]
   expect_true(alpha_decay1_in < alpha_decay1_ul & alpha_decay1_in > alpha_decay1_ll)
 })
+
+### make test that weights are used correctly and malformatted weights are detected
+test_that("weights work", {
+
+  # all weights should be 1
+  df <- make_data(phi1 = 6)
+  out <- circacompare(
+    x = df, col_time = "time", col_outcome = "measure", col_group = "group"
+  )
+  expect_true(all(out$fit$weights == 1))
+
+  # all weights should not be 1
+  sw <- runif(n=nrow(df))
+  out2 <- circacompare(
+    x = df, col_time = "time", col_outcome = "measure", col_group = "group",
+    weights = sw
+  )
+  expect_false(all(out2$fit$weights == 1))
+
+  # weights must be same length as nrow(x)
+  sw2 <- c(sw, 1)
+  expect_error(
+    circacompare(
+      x = df, col_time = "time", col_outcome = "measure", col_group = "group",
+      weights = sw2
+    )
+  )
+
+  sw3 <- sw
+  sw3[1] <- NA
+  expect_error(
+    circacompare(
+      x = df, col_time = "time", col_outcome = "measure", col_group = "group",
+      weights = sw3
+    )
+  )
+
+})

--- a/tests/testthat/test-circacompare_mixed.R
+++ b/tests/testthat/test-circacompare_mixed.R
@@ -33,3 +33,99 @@ test_that("circacompare_mixed() works", {
   phi1_ul <- phi1_est + 1.96 * phi1_fit["std_error"]
   expect_true(phi1_in < phi1_ul & phi1_in > phi1_ll)
 })
+
+### make test that weights are used correctly and malformatted weights are detected
+test_that("weights work", {
+
+  set.seed(99)
+  phi1_in <- 3.15
+  mixed_data <- function(n) {
+    counter <- 1
+    for (i in 1:n) {
+      x <- make_data(k1 = 0, alpha1 = 0, phi1 = rnorm(1, phi1_in, 0.5), hours = 72, noise_sd = 1)
+      x$id <- counter
+      counter <- counter + 1
+      if (i == 1) {
+        res <- x
+      } else {
+        res <- rbind(res, x)
+      }
+    }
+    return(res)
+  }
+
+  df <- mixed_data(20)
+
+  out <- circacompare_mixed(
+    x = df,
+    col_time = "time",
+    col_group = "group",
+    col_outcome = "measure",
+    col_id = "id",
+    control = list(grouped_params = c("phi"), random_params = c("phi1"))
+  )
+
+  # no weights used (= all weights are 1), hence fit$apVar should not be populated
+  out <- circacompare_mixed(
+   x = df,
+   col_time = "time",
+   col_group = "group",
+   col_outcome = "measure",
+   col_id = "id",
+   control = list(grouped_params = c("phi"), random_params = c("phi1"))
+  )
+  expect_true(is(out$fit$apVar, "character"))
+
+  # when weights are not all 1 then fit$apVar should be a matrix
+  sw <- runif(n=nrow(df))
+  out2 <- circacompare_mixed(
+    x = df,
+    col_time = "time",
+    col_group = "group",
+    col_outcome = "measure",
+    col_id = "id",
+    control = list(grouped_params = c("phi"), random_params = c("phi1")),
+    weights = sw
+  )
+  expect_true(is(out2$fit$apVar, "matrix"))
+
+  # weights must be same length as nrow(x)
+  sw2 <- c(sw, 1)
+  expect_error(
+    circa_single_mixed(
+      x = df, col_time = "time", col_outcome = "measure",
+      col_id = "id", randomeffects = c("k"), weights = sw2
+    )
+  )
+
+  # weights must not contain NA
+  sw3 <- sw
+  sw3[1] <- NA
+  expect_error(
+    circacompare_mixed(
+      x = df,
+      col_time = "time",
+      col_group = "group",
+      col_outcome = "measure",
+      col_id = "id",
+      control = list(grouped_params = c("phi"), random_params = c("phi1")),
+      weights = sw3
+    )
+  )
+
+  # weights must not be negative
+  sw4 <- sw
+  sw4[1] <- -1
+  expect_error(
+    circacompare_mixed(
+      x = df,
+      col_time = "time",
+      col_group = "group",
+      col_outcome = "measure",
+      col_id = "id",
+      control = list(grouped_params = c("phi"), random_params = c("phi1")),
+      weights = sw4
+    )
+  )
+
+})

--- a/tests/testthat/test-circacompare_mixed.R
+++ b/tests/testthat/test-circacompare_mixed.R
@@ -36,7 +36,6 @@ test_that("circacompare_mixed() works", {
 
 ### make test that weights are used correctly and malformatted weights are detected
 test_that("weights work", {
-
   set.seed(99)
   phi1_in <- 3.15
   mixed_data <- function(n) {
@@ -67,17 +66,17 @@ test_that("weights work", {
 
   # no weights used (= all weights are 1), hence fit$apVar should not be populated
   out <- circacompare_mixed(
-   x = df,
-   col_time = "time",
-   col_group = "group",
-   col_outcome = "measure",
-   col_id = "id",
-   control = list(grouped_params = c("phi"), random_params = c("phi1"))
+    x = df,
+    col_time = "time",
+    col_group = "group",
+    col_outcome = "measure",
+    col_id = "id",
+    control = list(grouped_params = c("phi"), random_params = c("phi1"))
   )
   expect_true(is(out$fit$apVar, "character"))
 
   # when weights are not all 1 then fit$apVar should be a matrix
-  sw <- runif(n=nrow(df))
+  sw <- runif(n = nrow(df))
   out2 <- circacompare_mixed(
     x = df,
     col_time = "time",
@@ -132,5 +131,4 @@ test_that("weights work", {
       weights = sw4
     )
   )
-
 })

--- a/tests/testthat/test-circacompare_mixed.R
+++ b/tests/testthat/test-circacompare_mixed.R
@@ -92,9 +92,14 @@ test_that("weights work", {
   # weights must be same length as nrow(x)
   sw2 <- c(sw, 1)
   expect_error(
-    circa_single_mixed(
-      x = df, col_time = "time", col_outcome = "measure",
-      col_id = "id", randomeffects = c("k"), weights = sw2
+    circacompare_mixed(
+      x = df,
+      col_time = "time",
+      col_group = "group",
+      col_outcome = "measure",
+      col_id = "id",
+      control = list(grouped_params = c("phi"), random_params = c("phi1")),
+      weights = sw2
     )
   )
 


### PR DESCRIPTION
Dear Rex, 

following up late on https://github.com/RWParsons/circacompare/issues/7 I added sample weights support to both `circacompare()`, `circa_single()` and `model_each_group()` (the `nls()` part of it) and added a toy example to the `@examples`. 

I intentionally did not add it to the mixed effect functions as it is unclear to me how. I think it is via something like `nlme(..., weights = varPower(form=~sample_weights))` but nlme documentation and google search did not make me confident enough to add it. 

Right now `circacompare()` and `circa_single()` have a new argument `sample_weights` that write the sample weights to the `nls()` input data, or when weights are NULL (the default) it simply adds a `1` per sample, so no weighting takes place. 

Please have a look if you have time.

best,
Alex